### PR TITLE
Correct the description of Esc + c (Alt+c, M-c)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Esc + u
 Esc + l
 # converts text from cursor to the end of the word to lowercase.
 Esc + c
-# converts letter under the cursor to uppercase.
+# converts letter under the cursor to uppercase, rest of the word to lowercase.
 ```
 ##### Run history number (e.g. 53)
 ```bash


### PR DESCRIPTION
README.md contains an incorrect description of `Esc + c` (or `M-c` in the docs, see `info readline` then `/M-c` and press `Enter`) readline shortcut key. It doesn't only convert the letter under the cursor to uppercase, it executes the `capitalize-word` command, which also converts the rest of the word to lowercase.

As a demonstration, you can type:
```
$ oneTwoThree FourFive
```
then press `Ctrl+A` to position the cursor to the start of the line, and press `Alt+C`. It will produce:
```
$ Onetwothree FourFive
```