### PR TITLE
Use equivalent regex with PCRE

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ grep -c "^$"
 ```bash
 grep -o '[0-9]*'
 #or
-grep -oP '\d'
+grep -oP '\d*'
 ```
 #####  Grep integer with certain number of digits (e.g. 3)
 ```bash


### PR DESCRIPTION
Use the equivalent regex with PCRE.

`[0-9]*` (and `\d*`) will output each integer, e.g.:

```bash
echo 17 | grep -o '[0-9]*'
# 17
```

Whereas `\d` will split it into digits, e.g.:

```bash
echo 17 | grep -oP '\d'
# 1
# 7
```