### PR TITLE
Update 'echo -n' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2590,7 +2590,9 @@ printf 'hello world\n%.0s' {1..5}
 ```
 ##### Do not echo the trailing newline
 ```bash
-username=`echo -n "bashoneliner"`
+echo -n "Doing the things... "
+# (do things)
+echo "done."
 ```
 
 ##### Copy a file to multiple files (e.g copy fileA to file(B-D))


### PR DESCRIPTION
Hi there @onceupon!

This updates the `echo -n` example to be a more straightforward use case, without any backticks.

The `-n` argument to `echo` in the current example doesn't have any actual effect, since a command substitution (backticks, or `$()` in Bash) _already_ removes the trailing newline(s) as part of its natural function.

Hope this helps!

—Kevin

References:
* <https://www.gnu.org/software/bash/manual/html_node/Command-Substitution.html>
* <http://heirloom.sourceforge.net/sh/sh.1.html#4>