### PR TITLE
Make formatting and names more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ sudo !!
 
 ##### Run last command and change some parameter using caret substitution (e.g. last command: echo 'aaa' -> rerun as: echo 'bbb')
 ```bash
-#last command: echo 'aaa'
+# last command: echo 'aaa'
 ^aaa^bbb
 
 #echo 'bbb'
 #bbb
 
-#Notice that only the first aaa will be replaced, if you want to replace all 'aaa', use ':&' to repeat it:
+# Notice that only the first aaa will be replaced, if you want to replace all 'aaa', use ':&' to repeat it:
 ^aaa^bbb^:&
-#or
+# or
 !!:gs/aaa/bbb/
 
 ```
@@ -218,7 +218,7 @@ echo ${var[@]#0}
 
 ##### Grep lines with strings from a file (e.g. lines with 'stringA or 'stringB' or 'stringC')
 ```bash
-#with grep
+# with grep
 test="stringA stringB stringC"
 grep ${test// /\\\|} file.txt
 # turning the space into 'or' (\|) in grep
@@ -318,7 +318,7 @@ grep -c "^$"
 #####  Grep and return only integer
 ```bash
 grep -o '[0-9]*'
-#or
+# or
 grep -oP '\d*'
 ```
 #####  Grep integer with certain number of digits (e.g. 3)
@@ -341,7 +341,7 @@ grep -Po '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}'
 ```bash
 grep -w 'target'
 
-#or using RE
+# or using RE
 grep '\btarget\b'
 ```
 #####  Grep returning lines before and after match (e.g. 'bbo')
@@ -379,7 +379,7 @@ grep -v '^#' file.txt
 ##### Grep variables with space within it (e.g. myvar="some strings")
 ```bash
 grep "$myvar" filename
-#remember to quote the variable!
+# remember to quote the variable!
 ```
 
 ##### Grep only one/first match (e.g. 'bbo')
@@ -458,8 +458,8 @@ grep $'\t'
 ```bash
 $echo "$long_str"|grep -q "$short_str"
 if [ $? -eq 0 ]; then echo 'found'; fi
-#grep -q will output 0 if match found
-#remember to add space between []!
+# grep -q will output 0 if match found
+# remember to add space between []!
 ```
 
 ##### Grep strings between a bracket()
@@ -545,7 +545,7 @@ sed -i '$ s/.$//' filename
 
 ##### Add string to beginning of file (e.g. "\[")
 ```bash
-sed -i '1s/^/[/' file
+sed -i '1s/^/[/' filename
 ```
 
 ##### Add string at certain line number (e.g. add 'something' to line 1 and line 3)
@@ -692,7 +692,7 @@ sed '$ s/.$//'
 
 ##### Insert character at specified position of file (e.g. AAAAAA --> AAA#AAA)
 ```bash
-sed -r -e 's/^.{3}/&#/' file
+sed -r -e 's/^.{3}/&#/' filename
 ```
 
 
@@ -747,7 +747,7 @@ awk -v N=7 '{print}/bbo/&& --N<=0 {exit}'
 
 ##### Print filename and last line of all files in directory
 ```bash
-ls|xargs -n1 -I file awk '{s=$0};END{print FILENAME,s}' file
+ls|xargs -n1 -I file awk '{s=$0};END{print FILENAME,s}' filename
 ```
 
 ##### Add string to the beginning of a column (e.g add "chr" to column $3)
@@ -757,12 +757,12 @@ awk 'BEGIN{OFS="\t"}$3="chr"$3'
 
 ##### Remove lines with string (e.g. 'bbo')
 ```bash
-awk '!/bbo/' file
+awk '!/bbo/' filename
 ```
 
 ##### Remove last column
 ```bash
-awk 'NF{NF-=1};1' file
+awk 'NF{NF-=1};1' filename
 ```
 
 ##### Usage and meaning of NR and FNR
@@ -827,7 +827,7 @@ awk '{printf("%s\t%s\n",NR,$0)}'
 # David    cat
 # David    dog
 
-awk '{split($2,a,",");for(i in a)print $1"\t"a[i]}' file
+awk '{split($2,a,",");for(i in a)print $1"\t"a[i]}' filename
 
 # Detail here:　http://stackoverflow.com/questions/33408762/bash-turning-single-comma-separated-column-into-multi-line-string
 ```
@@ -941,7 +941,7 @@ find /dir/to/A -type f -name "*.py" -print 0| xargs -0 -r -I file cp -v -p file 
 
 ##### With sed
 ```bash
-ls |xargs -n1 -I file sed -i '/^Pos/d' file
+ls |xargs -n1 -I file sed -i '/^Pos/d' filename
 ```
 
 ##### Add the file name to the first line of file
@@ -1053,8 +1053,8 @@ else
 fi
 
 # if variable is null
-if [ ! -s "myvariable" ]; then echo -e "variable is null!" ; fi
-#True of the length if "STRING" is zero.
+if [ ! -s "$myvariable" ]; then echo -e "variable is null!" ; fi
+# True of the length if "STRING" is zero.
 
 # Using test command (same as []), to test if the length of variable is nonzero
 test -n "$myvariable" && echo myvariable is "$myvariable" || echo myvariable is not set
@@ -1091,7 +1091,7 @@ if [[ $age -gt 21 ]]; then echo -e "forever 21!!" ; fi
 ```bash
 # Echo the file name under the current directory
 for i in $(ls); do echo file $i; done
-#or
+# or
 for i in *; do echo file $i; done
 
 # Make directories listed in a file (e.g. myfile)
@@ -1104,10 +1104,10 @@ for i in $(cat tpc_stats_0925.log |grep failed|grep -o '\query\w\{1,2\}'); do ca
 oifs="$IFS"; IFS=$'\n'; for line in $(cat myfile); do ...; done
 while read -r line; do ...; done <myfile
 
-#If only one word a line, simply
+# If only one word a line, simply
 for line in $(cat myfile); do echo $line; read -n1; done
 
-#Loop through an array
+# Loop through an array
 for i in "${arrayName[@]}"; do echo $i; done
 
 ```
@@ -1216,7 +1216,7 @@ TMOUT=10
 
 ##### Set how long you want to run a command
 ```bash
-#This will run the command 'sleep 10' for only 1 second.
+# This will run the command 'sleep 10' for only 1 second.
 timeout 1 sleep 10
 ```
 
@@ -1585,7 +1585,7 @@ who -r
 ##### Change SysV runlevel (e.g. 5)
 ```bash
 init 5
-#or
+# or
 telinit 5
 ```
 
@@ -1787,7 +1787,7 @@ pushd .
 # then pop
 popd
 
-#or use dirs to display the list of currently remembered directories.
+# or use dirs to display the list of currently remembered directories.
 dirs -l
 ```
 
@@ -1798,7 +1798,7 @@ df -h
 # or
 du -h
 
-#or
+# or
 du -sk /var/log/* |sort -rn |head -10
 ```
 
@@ -1828,7 +1828,7 @@ runlevel
 ```bash
 init 3
 
-#or
+# or
 telinit 3
 ```
 
@@ -2145,7 +2145,7 @@ ps aux|grep python
 ```bash
 ps -p <PID>
 
-#or
+# or
 cat /proc/<PID>/status
 cat /proc/<PID>/stack
 cat /proc/<PID>/stat
@@ -2193,21 +2193,21 @@ sudo dpkg --purge <package_name>
 ```bash
 ssh -f -L 9000:targetservername:8088 root@192.168.14.72 -N
 #-f: run in background; -L: Listen; -N: do nothing
-#the 9000 of your computer is now connected to the 8088 port of the targetservername through 192.168.14.72
-#so that you can see the content of targetservername:8088 by entering localhost:9000 from your browser.
+# the 9000 of your computer is now connected to the 8088 port of the targetservername through 192.168.14.72
+# so that you can see the content of targetservername:8088 by entering localhost:9000 from your browser.
 ```
 ##### Get process ID of a process (e.g. sublime_text)
 ```bash
-#pidof
+# pidof
 pidof sublime_text
 
-#pgrep, you don't have to type the whole program name
+# pgrep, you don't have to type the whole program name
 pgrep sublim
 
-#pgrep, echo 1 if process found, echo 0 if no such process
+# pgrep, echo 1 if process found, echo 0 if no such process
 pgrep -q sublime_text && echo 1 || echo 0
 
-#top, takes longer time
+# top, takes longer time
 top|grep sublime_text
 ```
 
@@ -2490,7 +2490,7 @@ $ sudo nc -l 80
 
 ##### Check which ports are listening for TCP connections from the network
 ```bash
-#notice that some companies might not like you using nmap
+# note that some companies might not like you using nmap
 nmap -sT -O localhost
 
 # check port 0-65535
@@ -2498,7 +2498,7 @@ nmap  -p0-65535 localhost
 ```
 ##### Check if a host is up and scan for open ports, also skip host discovery.
 ```bash
-#skips checking if the host is alive which may sometimes cause a false positive and stop the scan.
+# skips checking if the host is alive. this may sometimes cause a false positive, stopping the scan.
 $ nmap google.com -Pn
 
 # Example output:
@@ -2520,7 +2520,7 @@ $ nmap -A -T4 scanme.nmap.org
 # -A to enable OS and version detection, script scanning, and traceroute; -T4 for faster execution
 ```
 
-##### Look up website information (e.g. name server), searches for an object in a RFC 3912 database.
+##### Look up website information (e.g. name server), searches for an object in a RFC 3912 database
 ```bash
 whois google.com
 ```
@@ -2731,11 +2731,11 @@ comm -23 fileA fileB
 ```bash
 nl fileA
 
-#or
+# or
 nl -nrz fileA
 # add leading zeros
 
-#or
+# or
 nl -w1 -s ' '
 # making it simple, blank separate
 ```
@@ -2870,7 +2870,7 @@ echo -e 'text here \c'
 
 ##### View first 50 characters of file
 ```bash
-head -c 50 file
+head -c 50 filename
 ```
 
 ##### Cut and get last column of a file
@@ -2926,9 +2926,9 @@ echo 'hihi' >>filename
 
 ##### Working with json data
 ```bash
-#install the useful jq package
-#sudo apt-get install jq
-#e.g. to get all the values of the 'url' key, simply pipe the json to the following jq command(you can use .[]. to select inner json, i.e jq '.[].url')
+# Install the useful jq package
+# sudo apt-get install jq
+# e.g. to get all the values of the 'url' key, simply pipe the json to the following jq command(you can use .[]. to select inner json, i.e jq '.[].url')
 cat file.json | jq '.url'
 ```
 
@@ -3001,7 +3001,7 @@ while read a b; do yes $b |head -n $a ; done <test.txt
 ## Others
 [[back to top](#handy-bash-one-liners)]
 
-##### Describe the format and characteristics of image files.
+##### Describe the format and characteristics of image files
 ```bash
 identify myimage.png
 #myimage.png PNG 1049x747 1049x747+0+0 8-bit sRGB 1.006MB 0.000u 0:00.000
@@ -3124,7 +3124,7 @@ history -w
 vi ~/.bash_history
 history -r
 
-#or
+# or
 history -d [line_number]
 ```
 


### PR DESCRIPTION
I noticed that most comments started with `# ` (with a space after). I changed most of the remaining comments to be similar.

I noticed that most filenames were 'filename' and there were a few named 'file'. I changed ones named 'file' to 'filename'.

Improved some comment text.

I fixed a bug on line 1056, where `$myvariable` was missing a quote